### PR TITLE
fix: state/trn hooks not called on polysyllabic state/trn names

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,9 @@
+import { is } from './is.js'
+
 const utils = {
   String: {
     onify: function(str) {
-      return `on${str.charAt(0).toUpperCase()}${str.slice(1).toLowerCase()}` 
+      return is.string(`on${str.charAt(0).toUpperCase()}${str.slice(1)}`)
     }
   },
 

--- a/test/transition/hook-names.test.js
+++ b/test/transition/hook-names.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import { fsm } from '../../src/index.js'
+
+// Superlight, verify fix for:
+// - https://github.com/nicholaswmin/fsm/issues/1 
+
+test('#transitionFn(), polysyllable-named hooks', async t => {
+  let turnstile, hooks
+
+  t.beforeEach(() => {
+    hooks = {
+      onCoinDropped() {},
+      onOpenedLock() {},
+    }
+
+    turnstile = fsm({
+      closedLock: { coinDropped: 'openedLock' },
+      openedLock: { pushThrough: 'closedLock' }
+    }, hooks)
+  })
+  
+  await t.test('calling polysyllabic transition method', async t => {     
+    await t.test('calls polysyllabic transition hook', async t => {    
+      const onCoinDropped = t.mock.method(hooks, 'onCoinDropped')
+
+      turnstile.coinDropped('foo', 'bar')
+
+      await t.test('once', t => {
+        t.assert.strictEqual(onCoinDropped.mock.callCount(), 1)
+      })
+    })
+
+    
+    await t.test('calls polysyllabic state change hook', async t => {  
+      const onOpenedLock = t.mock.method(turnstile, 'onOpenedLock')
+      
+      turnstile.coinDropped('foo', 'bar')
+
+      await t.test('once', t => {
+        t.assert.strictEqual(onOpenedLock.mock.callCount(), 1)
+      })
+    })
+  })
+})

--- a/test/utils/string/onify.test.js
+++ b/test/utils/string/onify.test.js
@@ -1,0 +1,105 @@
+import test from 'node:test'
+import utils from '../../../src/utils.js'
+
+// - Polysyllabic test case fixes: https://github.com/nicholaswmin/fsm/issues/1
+
+test('#utils String.onify(str)', async t => {
+  const result = utils.String.onify('foo')
+
+  await t.test('returns a result', t => {     
+    t.assert.ok(result, `${result} is falsy`)
+  })
+
+  await t.test('returns a string', t => {     
+    t.assert.strictEqual(typeof result, 'string')
+  })
+
+  await t.test('passing an all-lowercase string', async t => {     
+    const result = utils.String.onify('foo')
+
+    await t.test('appends "on"', async t => {     
+      t.assert.ok(result.startsWith('on'), `got: ${result} instead`)
+      
+      await t.test('just once', t => {     
+        t.assert.strictEqual(result.split('on').length, 2)
+      })
+    })
+    
+    await t.test('uppercases 1st char', async t => {     
+      t.assert.strictEqual(result[2], 'F')
+
+      await t.test('remainder is unchanged', t => {     
+        t.assert.strictEqual(result.split('onF').slice(1).join(''), 'oo')
+      })
+    })
+  })
+})
+
+test('#String.onify(str) monosyllabic string argument', async t => {
+  await t.test('passing a monosyllabic camelCase string', async t => {     
+    const result = utils.String.onify('fooBar')
+    
+    await t.test('appends "on"', async t => {     
+      t.assert.ok(result.startsWith('on'), `got: ${result} instead`)
+  
+      await t.test('just once', t => {     
+        t.assert.strictEqual(result.split('on').length, 2)
+      })
+    })
+    
+    await t.test('uppercases 1st char', async t => {     
+      t.assert.strictEqual(result[2], 'F')
+  
+      await t.test('remainder is unchanged', t => {     
+        t.assert.strictEqual(result.split('onF').slice(1).join(''), 'ooBar')
+      })
+    })
+  })
+})
+
+test('#String.onify(str) polysyllabic str argument', async t => {
+  await t.test('passing a polysyllabic camelCase string', async t => {     
+    const result = utils.String.onify('fooBarBaz')
+
+    await t.test('appends "on"', async t => {     
+      t.assert.ok(result.startsWith('on'), `got: ${result} instead`)
+
+      await t.test('just once', t => {     
+        t.assert.strictEqual(result.split('on').length, 2)
+      })
+    })
+    
+    await t.test('uppercases 1st char', async t => {     
+      t.assert.strictEqual(result[2], 'F')
+
+      await t.test('remainder is unchanged', t => {   
+        t.assert.strictEqual(result.split('onF').slice(1).join(''), 'ooBarBaz')
+      })
+    })
+  })
+})
+
+
+test('String.onify invalid argument', async t => {
+  await t.test('passed nothing', t => {     
+    return t.assert.throws(() => utils.String.onify(), {
+      name: 'TypeError'
+    })
+  })
+  
+  await t.test('passed a non-string', async t => {     
+    await t.test('throws a TypeError', t => {     
+      return t.assert.throws(() => utils.String.onify(351), {
+        name: 'TypeError'
+      })
+    })
+  })
+
+  await t.test('passed empty string', async t => {     
+    await t.test('throws a RangeError', t => {     
+      return t.assert.throws(() => utils.String.onify(' '), {
+        name: 'RangeError'
+      })
+    })
+  })    
+})


### PR DESCRIPTION
## fix

- fixes #1 

## test 

- verifies fix with unit-tests